### PR TITLE
Produce JSON schema when run as main

### DIFF
--- a/aiod_registry/schema.json
+++ b/aiod_registry/schema.json
@@ -1,0 +1,417 @@
+{
+  "$defs": {
+    "Author": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "affiliation": {
+          "title": "Affiliation",
+          "type": "string"
+        },
+        "email": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Email"
+        },
+        "url": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Url"
+        },
+        "github": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Github"
+        },
+        "orcid": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Orcid"
+        }
+      },
+      "required": [
+        "name",
+        "affiliation"
+      ],
+      "title": "Author",
+      "type": "object"
+    },
+    "Metadata": {
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "description": "A short description of the model to provide context.",
+          "title": "Description",
+          "type": "string"
+        },
+        "authors": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/Author"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Authors"
+        },
+        "pubs": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/Publication"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Pubs"
+        },
+        "url": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Url"
+        },
+        "repo": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Repo"
+        }
+      },
+      "required": [
+        "description"
+      ],
+      "title": "Metadata",
+      "type": "object"
+    },
+    "ModelParam": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Name of the parameter. If `arg_name` is not provided, this will be used as the argument name to the underlying model.",
+          "maxLength": 50,
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "arg_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Arg Name"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ]
+              },
+              "type": "array"
+            }
+          ],
+          "description": "Default parameter value. If a list, the parameters will be treated as dropdown choices, where the first is the default. The type of the first element will be used to determine the type of the parameter.",
+          "title": "Value"
+        },
+        "tooltip": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tooltip"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "title": "ModelParam",
+      "type": "object"
+    },
+    "ModelVersion": {
+      "additionalProperties": false,
+      "properties": {
+        "tasks": {
+          "patternProperties": {
+            "^(?i:mito|er|ne|everything)$": {
+              "$ref": "#/$defs/ModelVersionTask"
+            }
+          },
+          "title": "Tasks",
+          "type": "object"
+        }
+      },
+      "required": [
+        "tasks"
+      ],
+      "title": "ModelVersion",
+      "type": "object"
+    },
+    "ModelVersionTask": {
+      "additionalProperties": false,
+      "properties": {
+        "location": {
+          "description": "Either a url or a filepath (will be skipped if the path does not exist/cannot be read!)",
+          "title": "Location",
+          "type": "string"
+        },
+        "config_path": {
+          "anyOf": [
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Config Path"
+        },
+        "params": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/ModelParam"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Params"
+        },
+        "location_type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Location Type"
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "title": "ModelVersionTask",
+      "type": "object"
+    },
+    "Publication": {
+      "additionalProperties": false,
+      "properties": {
+        "info": {
+          "description": "Information on publication, whether it pertains to the model or the underlying data or something else.",
+          "title": "Info",
+          "type": "string"
+        },
+        "url": {
+          "format": "uri",
+          "minLength": 1,
+          "title": "Url",
+          "type": "string"
+        },
+        "doi": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Doi"
+        },
+        "authors": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/Author"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Authors"
+        }
+      },
+      "required": [
+        "info",
+        "url"
+      ],
+      "title": "Publication",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "maxLength": 50,
+      "minLength": 1,
+      "title": "Name",
+      "type": "string"
+    },
+    "short_name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Short Name"
+    },
+    "versions": {
+      "additionalProperties": {
+        "$ref": "#/$defs/ModelVersion"
+      },
+      "title": "Versions",
+      "type": "object"
+    },
+    "params": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/ModelParam"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Params"
+    },
+    "config": {
+      "anyOf": [
+        {
+          "format": "path",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Config"
+    },
+    "metadata": {
+      "$ref": "#/$defs/Metadata"
+    }
+  },
+  "required": [
+    "name",
+    "versions",
+    "metadata"
+  ],
+  "title": "ModelManifest",
+  "type": "object"
+}

--- a/aiod_registry/schema.py
+++ b/aiod_registry/schema.py
@@ -155,3 +155,13 @@ class ModelManifest(StrictModel):
             for task in version.tasks.values():
                 if task.params is None:
                     task.params = self.params
+
+
+if __name__ == "__main__":
+    import json
+
+    schema_fpath = Path(__file__).parent / "schema.json"
+
+    # Write the schema to file
+    with open(schema_fpath, "w") as f:
+        f.write(json.dumps(ModelManifest.model_json_schema(), indent=2))


### PR DESCRIPTION
Directly create the schema from `schema.py` when run, as created by Pydantic.