### PR TITLE
Re-org Schema for Napari v0.4.19 upgrade

### DIFF
--- a/aiod_registry/__init__.py
+++ b/aiod_registry/__init__.py
@@ -1,2 +1,2 @@
-from aiod_registry.schema import ModelManifest
+from aiod_registry.schema import ModelManifest, TASK_NAMES
 from aiod_registry.utils import get_manifest_paths, load_manifests

--- a/aiod_registry/manifests/mitonet.json
+++ b/aiod_registry/manifests/mitonet.json
@@ -19,47 +19,49 @@
     "params": [
     {
         "name": "Plane",
+        "arg_name": "plane",
         "value": ["XY", "XZ", "YZ", "All"],
         "tooltip": "Whether to use all planes (XY, XZ, YZ) or a single plane"
     },
     {
         "name": "Downsampling",
+        "arg_name": "downsampling",
         "value": [1, 2, 4, 8, 16, 32, 64],
         "tooltip": "Downsampling factor for the input image"
     },
     {
         "name": "Segmentation threshold",
-        "short_name": "conf_threshold",
+        "arg_name": "conf_threshold",
         "value": 0.5,
         "tooltip": "Confidence threshold for the segmentation"
     },
     {
         "name": "Center threshold",
-        "short_name": "center_threshold",
+        "arg_name": "center_threshold",
         "value": 0.1,
         "tooltip": "Confidence threshold for the center"
     },
     {
         "name": "Minimum distance",
-        "short_name": "min_distance",
+        "arg_name": "min_distance",
         "value": 3,
         "tooltip": "Minimum distance between object centers"
     },
     {
         "name": "Maximum objects",
-        "short_name": "max_objects",
+        "arg_name": "max_objects",
         "value": 1000,
         "tooltip": "Maximum number of objects to segment per class"
     },
     {
         "name": "Semantic only",
-        "short_name": "semantic_only",
+        "arg_name": "semantic_only",
         "value": false,
         "tooltip": "Only run semantic segmentation for all classes"
     },
     {
         "name": "Fine boundaries",
-        "short_name": "fine_boundaries",
+        "arg_name": "fine_boundaries",
         "value": false,
         "tooltip": "Finer boundaries between objects"
     }

--- a/aiod_registry/manifests/mitonet.json
+++ b/aiod_registry/manifests/mitonet.json
@@ -1,25 +1,21 @@
 {
     "name": "Mitonet",
-    "versions": [
-      {
-        "name": "MitoNet v1",
-        "tasks": [
-          {
-            "task": "mito",
+    "versions": {
+      "MitoNet v1": {
+        "tasks": {
+          "mito": {
             "location": "https://zenodo.org/record/6861565/files/MitoNet_v1.pth?download=1"
           }
-        ]
+        }
       },
-      {
-        "name": "MitoNet Mini v1",
-        "tasks": [
-          {
-            "task": "mito",
+      "MitoNet Mini v1": {
+        "tasks": {
+          "mito": {
             "location": "https://zenodo.org/record/6861565/files/MitoNet_v1_mini.pth?download=1"
           }
-        ]
+        }
       }
-    ],
+    },
     "params": [
     {
         "name": "Plane",

--- a/aiod_registry/manifests/sam.json
+++ b/aiod_registry/manifests/sam.json
@@ -1,6 +1,6 @@
 {
   "name": "Segment Anything",
-  "arg_name": "sam",
+  "short_name": "sam",
   "versions": {
     "default": {
       "tasks": {

--- a/aiod_registry/manifests/sam.json
+++ b/aiod_registry/manifests/sam.json
@@ -1,6 +1,6 @@
 {
   "name": "Segment Anything",
-  "short_name": "sam",
+  "arg_name": "sam",
   "versions": {
     "default": {
       "tasks": {
@@ -41,67 +41,67 @@
   "params": [
     {
         "name": "Points per side",
-        "short_name": "points_per_side",
+        "arg_name": "points_per_side",
         "value": 32,
         "tooltip": ""
     },
     {
         "name": "Points per batch",
-        "short_name": "points_per_batch",
+        "arg_name": "points_per_batch",
         "value": 64,
         "tooltip": ""
     },
     {
         "name": "Pred IoU threshold",
-        "short_name": "pred_iou_thresh",
+        "arg_name": "pred_iou_thresh",
         "value": 0.88,
         "tooltip": ""
     },
     {
         "name": "Stability score threshold",
-        "short_name": "stability_score_thresh",
+        "arg_name": "stability_score_thresh",
         "value": 0.95,
         "tooltip": ""
     },
     {
         "name": "Stability score offset",
-        "short_name": "stability_score_offset",
+        "arg_name": "stability_score_offset",
         "value": 1,
         "tooltip": ""
     },
     {
         "name": "Box nms_thresh",
-        "short_name": "box_nms_thresh",
+        "arg_name": "box_nms_thresh",
         "value": 0.7,
         "tooltip": ""
     },
     {
         "name": "Crop N layers",
-        "short_name": "crop_n_layers",
+        "arg_name": "crop_n_layers",
         "value": 0,
         "tooltip": ""
     },
     {
         "name": "Crop NMS thresh",
-        "short_name": "crop_nms_thresh",
+        "arg_name": "crop_nms_thresh",
         "value": 0.7,
         "tooltip": ""
     },
     {
         "name": "Crop overlap ratio",
-        "short_name": "crop_overlap_ratio",
+        "arg_name": "crop_overlap_ratio",
         "value": 0.34133,
         "tooltip": ""
     },
     {
         "name": "Crop B points downscale factor",
-        "short_name": "crop_n_points_downscale_factor",
+        "arg_name": "crop_n_points_downscale_factor",
         "value": 0.5,
         "tooltip": ""
     },
     {
         "name": "Min mask region area",
-        "short_name": "min_mask_region_area",
+        "arg_name": "min_mask_region_area",
         "value": 3,
         "tooltip": ""
     }

--- a/aiod_registry/manifests/sam.json
+++ b/aiod_registry/manifests/sam.json
@@ -1,58 +1,43 @@
 {
   "name": "Segment Anything",
   "short_name": "sam",
-  "versions": [
-    {
-      "name": "default",
-      "tasks": [
-        {
-          "task": "everything",
-          "location": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth",
-          "config_path": null
+  "versions": {
+    "default": {
+      "tasks": {
+        "everything": {
+          "location": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth"
         }
-      ]
+      }
     },
-    {
-      "name": "vit_h",
-      "tasks": [
-        {
-          "task": "everything",
-          "location": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth",
-          "config_path": null
+    "vit_h": {
+      "tasks": {
+        "everything": {
+          "location": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth"
         }
-      ]
+      }
     },
-    {
-      "name": "vit_l",
-      "tasks": [
-        {
-          "task": "everything",
-          "location": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_l_0b3195.pth",
-          "config_path": null
+    "vit_l": {
+      "tasks": {
+        "everything": {
+          "location": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_l_0b3195.pth"
         }
-      ]
+      }
     },
-    {
-      "name": "vit_b",
-      "tasks": [
-        {
-          "task": "Mito",
-          "location":"https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth",
-          "config_path": null
+    "vit_b": {
+      "tasks": {
+        "everything": {
+          "location":"https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth"
         }
-      ]
+      }
     },
-    {
-      "name": "MedSAM",
-      "tasks": [
-        {
-          "task": "everything",
-          "location": "https://syncandshare.desy.de/index.php/s/yLfdFbpfEGSHJWY/download/medsam_20230423_vit_b_0.0.1.pth",
-          "config_path": null
+    "MedSAM": {
+      "tasks": {
+        "everything": {
+          "location": "https://syncandshare.desy.de/index.php/s/yLfdFbpfEGSHJWY/download/medsam_20230423_vit_b_0.0.1.pth"
         }
-      ]
+      }
     }
-  ],
+  },
   "params": [
     {
         "name": "Points per side",

--- a/aiod_registry/manifests/unet_seai.json
+++ b/aiod_registry/manifests/unet_seai.json
@@ -1,31 +1,26 @@
 {
   "name": "SEAI U-Net",
   "short_name": "seai_unet",
-  "versions": [
-    {
-      "name": "U-Net",
-      "tasks": [
-        {
-          "task": "mito",
-          "location": "/nemo/stp/ddt/working/shandc/aiod_models/mito_5nm_intensity_augs_warp.best.969.pt",
-          "config_path": "/nemo/stp/ddt/working/shandc/aiod_models/mito_5nm_intensity_augs_warp.yml"
+  "versions": {
+    "U-Net": {
+      "tasks": {
+        "mito": {
+          "location": "/Users/shandc/Documents/ai_ondemand/mito_5nm_intensity_augs_warp.best.969.pt",
+          "config_path": "/Users/shandc/Documents/ai_ondemand/mito_5nm_intensity_augs_warp.yml"
         }
-      ]
+      }
     },
-    {
-      "name": "Attention U-Net",
-      "tasks": [
-        {
-          "task": "mito",
+    "Attention U-Net": {
+      "tasks": {
+        "mito": {
           "location": "/nemo/stp/ddt/working/shandc/aiod_models/Attention_HUNet_3e5_Adam_restart_12_16.best.1266.pt",
           "config_path": "/nemo/stp/ddt/working/shandc/aiod_models/Attention_HUNet_3e5_Adam_restart_12_16.yml"
         },
-        {
-          "task": "ne",
+        "ne": {
           "location": "/nemo/stp/ddt/working/shandc/aiod_models/Attention_HUNet_NE.best.368.pt",
           "config_path": "/nemo/stp/ddt/working/shandc/aiod_models/Attention_HUNet_NE.yml"
         }
-      ]
+      }
     }
-  ]
+  }
 }

--- a/aiod_registry/schema.py
+++ b/aiod_registry/schema.py
@@ -18,7 +18,15 @@ task_names = "|".join(TASK_NAMES.keys())
 # Regex pattern to match task names, ignoring case
 Task = Annotated[str, Field(..., pattern=rf"^(?i:{task_names})$")]
 ModelName = Annotated[str, Field(..., min_length=1, max_length=50)]
-ParamName = Annotated[str, Field(..., min_length=1, max_length=50)]
+ParamName = Annotated[
+    str,
+    Field(
+        ...,
+        min_length=1,
+        max_length=50,
+        description="Name of the parameter. If `arg_name` is not provided, this will be used as the argument name to the underlying model.",
+    ),
+]
 ParamValue = Union[str, int, float, bool, list[Union[str, int, float, bool]]]
 
 
@@ -32,14 +40,14 @@ class StrictModel(BaseModel):
 
 class ModelParam(StrictModel):
     name: ParamName
-    short_name: Optional[str] = None
+    arg_name: Optional[str] = None
     value: ParamValue
     tooltip: Optional[str] = None
 
     @model_validator(mode="after")
-    def create_short_name(self):
-        if self.short_name is None:
-            self.short_name = shorten_name(self.name)
+    def create_arg_name(self):
+        if self.arg_name is None:
+            self.arg_name = self.name
         return self
 
 

--- a/aiod_registry/schema.py
+++ b/aiod_registry/schema.py
@@ -1,8 +1,25 @@
-import json
 from pathlib import Path
 from typing import Optional, Union
+from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator, AnyUrl
+from typing_extensions import Annotated
+
+TASK_NAMES = {
+    "mito": "Mitochondria",
+    "er": "Endoplasmic Reticulum",
+    "ne": "Nuclear Envelope",
+    "everything": "Everything!",
+}
+task_names = "|".join(TASK_NAMES.keys())
+
+# Define custom types/fields
+# Centralise to make it easier to change later
+# Regex pattern to match task names, ignoring case
+Task = Annotated[str, Field(..., pattern=rf"^(?i:{task_names})$")]
+ModelName = Annotated[str, Field(..., min_length=1, max_length=50)]
+ParamName = Annotated[str, Field(..., min_length=1, max_length=50)]
+ParamValue = Union[str, int, float, bool, list[Union[str, int, float, bool]]]
 
 
 def shorten_name(name: str) -> str:
@@ -13,25 +30,10 @@ class StrictModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class ModelVersionTask(StrictModel):
-    # Regex pattern to match task names, ignoring case
-    task: str = Field(..., pattern=r"^(?i:mito|er|ne|everything)$")
-    location: Union[Path, AnyUrl, str] = Field(
-        ...,
-        description="Either a url or a filepath (will be skipped if the path does not exist/cannot be read)",
-    )
-    config_path: Optional[Union[Path, str]] = None
-
-
-class ModelVersion(StrictModel):
-    name: str = Field(..., min_length=1, max_length=50)
-    tasks: list[ModelVersionTask]
-
-
 class ModelParam(StrictModel):
-    name: str = Field(..., min_length=1, max_length=50)
+    name: ParamName
     short_name: Optional[str] = None
-    value: Union[str, int, float, bool, list[Union[str, int, float, bool]]]
+    value: ParamValue
     tooltip: Optional[str] = None
 
     @model_validator(mode="after")
@@ -41,10 +43,42 @@ class ModelParam(StrictModel):
         return self
 
 
+class ModelVersionTask(StrictModel):
+    location: str = Field(
+        ...,
+        description="Either a url or a filepath (will be skipped if the path does not exist/cannot be read!)",
+    )
+    config_path: Optional[Union[Path, str]] = None
+    params: Optional[list[ModelParam]] = None
+    location_type: Optional[str] = None
+
+    @model_validator(mode="after")
+    def get_location_type(self):
+        # Skip if provided
+        if self.location_type is not None:
+            return self
+        # Otherwise, determine the type
+        res = urlparse(self.location)
+        if res.scheme in ("http", "https"):
+            self.location_type = "url"
+        elif res.scheme in ("file", ""):
+            self.location_type = "file"
+        else:
+            # NOTE: Because of including "" above, it is unlikely this will be reached
+            raise TypeError(
+                f"Cannot determine type (file/url) of location: {self.location}!"
+            )
+        return self
+
+
+class ModelVersion(StrictModel):
+    tasks: dict[Task, ModelVersionTask]
+
+
 class ModelManifest(StrictModel):
     name: str = Field(..., min_length=1, max_length=50)
     short_name: Optional[str] = None
-    versions: list[ModelVersion]
+    versions: dict[ModelName, ModelVersion]
     params: Optional[list[ModelParam]] = None
     config: Optional[Path] = None
 
@@ -53,3 +87,11 @@ class ModelManifest(StrictModel):
         if self.short_name is None:
             self.short_name = shorten_name(self.name)
         return self
+
+    # Embed base model params into each version if not provided
+    @model_validator(mode="after")
+    def fill_empty_params(self):
+        for version in self.versions.values():
+            for task in version.tasks.values():
+                if task.params is None:
+                    task.params = self.params


### PR DESCRIPTION
- Added more metadata to the schemas
- Re-organised key-value structure to allow for easier processing in Napari plugin (now possible in v0.4.19 due to previous pydantic v1 restriction)
- Added automatic output of schema into JSON format