### PR TITLE
AIOD-268: Empanada 3D + Default Values

### DIFF
--- a/aiod_registry/manifests/empanada.json
+++ b/aiod_registry/manifests/empanada.json
@@ -98,6 +98,43 @@
         "arg_name": "fine_boundaries",
         "value": false,
         "tooltip": "Finer boundaries between objects"
+    },
+    {
+        "name": "Fill holes",
+        "arg_name": "fill_holes_in_segmentation",
+        "value": false,
+        "tooltip": "Whether to fill holes in the segmentation masks"
+    },
+    {
+        "name": "Median Filter Size",
+        "arg_name": "median_slices",
+        "value": [1, 3, 5, 7, 9, 11],
+        "default": 3,
+        "tooltip": "Number of image slices over which to apply a median filter to semantic segmentation probabilities. Only applies to 3D/'All'."
+    },
+    {
+        "name": "Erode labels (px; 3D)",
+        "arg_name": "label_erosion",
+        "value": 0,
+        "tooltip": "Will erode objects in the masks by specified number of pixels before final consensus. Only applies to 3D/'All'."
+    },
+    {
+        "name": "Dilate labels (px; 3D)",
+        "arg_name": "label_dilation",
+        "value": 0,
+        "tooltip": "Will dilate objects in the masks by specified number of pixels before final consensus. Only applies to 3D/'All'."
+    },
+    {
+        "name": "Voxel Vote",
+        "arg_name": "pixel_vote_thr",
+        "value": 2,
+        "tooltip": "Number of stacks from ortho-plane inference in which a voxel must be labelled in order to end up in the consensus segmentation. Only applies to 3D/'All'."
+    },
+    {
+        "name": "Allow single-plane objects",
+        "arg_name": "allow_one_view",
+        "value": false,
+        "tooltip": "Whether to allow objects that are only segmented in a single plane (XY, XZ, or YZ) to be included in the final consensus segmentation. Only applies to 3D/'All'."
     }
     ]
   }

--- a/aiod_registry/schema.py
+++ b/aiod_registry/schema.py
@@ -35,7 +35,7 @@ ParamValue = Annotated[
     Union[str, int, float, bool, None, list[Union[str, int, float, bool]]],
     Field(
         ...,
-        description="Default parameter value. If a list, the parameters will be treated as dropdown choices, where the first is the default. The type of the first element will be used to determine the type of the parameter.",
+        description="Default parameter value. If a list, the parameters will be treated as dropdown choices. Use the `default` field on ModelParam to specify which item is selected by default (otherwise the first item is used). The type of the default (or first) element determines the parameter type.",
     ),
 ]
 Usage = Annotated[
@@ -70,6 +70,7 @@ class ModelParam(StrictModel):
     name: ParamName
     arg_name: Optional[str] = None
     value: ParamValue
+    default: Optional[Union[str, int, float, bool]] = None  # Override default for list values
     tooltip: Optional[str] = None
     dtype: Optional[str] = None  # Used of default value is None
     _dtype = None  # Determined from value if given
@@ -81,9 +82,23 @@ class ModelParam(StrictModel):
         return self
 
     @model_validator(mode="after")
+    def validate_default(self):
+        if self.default is not None:
+            if not isinstance(self.value, list):
+                raise ValueError(
+                    f"Parameter {self.name}: `default` can only be set when `value` is a list."
+                )
+            if self.default not in self.value:
+                raise ValueError(
+                    f"Parameter {self.name}: `default` value {self.default!r} is not in the choices list {self.value}."
+                )
+        return self
+
+    @model_validator(mode="after")
     def extract_arg_type(self):
         if isinstance(self.value, list):
-            self._dtype = type(self.value[0])
+            reference = self.default if self.default is not None else self.value[0]
+            self._dtype = type(reference)
         else:
             self._dtype = type(self.value)
         # If None, we need a dtype to poss cast to when dealing with GUIs

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,8 +3,9 @@ import os
 import sys
 
 import pytest
+from pydantic import ValidationError
 
-from aiod_registry.schema import ModelManifest
+from aiod_registry.schema import ModelManifest, ModelParam
 from aiod_registry.utils import (
     filter_empty_manifests,
     filter_location,
@@ -217,3 +218,33 @@ def test_is_accessible_permission_denied(tmp_path):
     finally:
         # Restore permissions so that pytest's tmp_path cleanup can delete the dir
         subdir.chmod(0o755)
+
+
+class TestModelParamDefault:
+    def test_list_no_default_uses_first(self):
+        """Without `default`, the first list item determines dtype and is the implicit default."""
+        p = ModelParam(name="mode", value=["fast", "slow", "accurate"])
+        assert p.default is None
+        assert p._dtype is str
+
+    def test_list_default_non_first_item(self):
+        """Setting `default` to a non-first list item is accepted and reflected in _dtype."""
+        p = ModelParam(name="mode", value=["fast", "slow", "accurate"], default="accurate")
+        assert p.default == "accurate"
+        assert p._dtype is str
+
+    def test_list_default_int(self):
+        """Integer default picks the correct dtype."""
+        p = ModelParam(name="level", value=[1, 2, 3], default=3)
+        assert p.default == 3
+        assert p._dtype is int
+
+    def test_default_not_in_list_raises(self):
+        """A `default` value that is not in the choices list must raise a ValidationError."""
+        with pytest.raises(ValidationError, match="not in the choices list"):
+            ModelParam(name="mode", value=["fast", "slow"], default="medium")
+
+    def test_default_on_scalar_raises(self):
+        """`default` is only valid for list values; a scalar value must raise a ValidationError."""
+        with pytest.raises(ValidationError, match="only be set when `value` is a list"):
+            ModelParam(name="thresh", value=0.5, default=0.5)


### PR DESCRIPTION
- Adds a default option for parameters to allow later use in e.g. Napari for selecting which value in a list should be the default
- Useful for the user and a move towards default configs for standalone Nextflow use
- Bundled with a few tests to check

This was required for expanding the Empanada schema with some 3D args