### PR TITLE
AIOD-302: Standardise Multi-Location Handling & Model Naming

### DIFF
--- a/aiod_registry/manifests/cellpose.json
+++ b/aiod_registry/manifests/cellpose.json
@@ -68,113 +68,129 @@
     "cyto3": {
       "tasks": {
         "cyto": {
-          "location":"https://www.cellpose.org/models/cyto3"
+          "locations": [
+            {
+              "location": "https://www.cellpose.org/models/cyto3"
+            }
+          ]
         }
       }
     },
     "nuclei": {
       "tasks": {
         "nuclei": {
-          "location": "https://www.cellpose.org/models/nucleitorch_0"
+          "locations": [
+            {
+              "location": "https://www.cellpose.org/models/nucleitorch_0"
+            }
+          ]
         }
       }
     },
     "cyto1": {
       "tasks": {
         "cyto": {
-          "location": "https://www.cellpose.org/models/cytotorch_0"
+          "locations": [
+            {
+              "location": "https://www.cellpose.org/models/cytotorch_0"
+            }
+          ]
         }
       }
     },
     "cyto2": {
       "tasks": {
         "cyto": {
-          "location":"https://www.cellpose.org/models/cyto2torch_0"
+          "locations": [
+            {
+              "location": "https://www.cellpose.org/models/cyto2torch_0"
+            }
+          ]
         }
       }
     }
   },
   "params": [
     {
-        "name": "Diameter",
-        "arg_name": "diameter",
-        "value": 0,
-        "tooltip": "Diameter of the cells in pixels. If None or 0, Cellpose will try to estimate it. Setting the value may improve results. See https://cellpose.readthedocs.io/en/v3.1.1.1/settings.html#diameter for details."
+      "name": "Diameter",
+      "arg_name": "diameter",
+      "value": 0,
+      "tooltip": "Diameter of the cells in pixels. If None or 0, Cellpose will try to estimate it. Setting the value may improve results. See https://cellpose.readthedocs.io/en/v3.1.1.1/settings.html#diameter for details."
     },
     {
-        "name": "Segment Channel",
-        "arg_name": "segment_channel",
-        "value": 0,
-        "tooltip": "What channel to segment on. 0=grayscale, 1=red, 2=green, 3=blue. See https://cellpose.readthedocs.io/en/v3.1.1.1/settings.html#channels for details."
+      "name": "Segment Channel",
+      "arg_name": "segment_channel",
+      "value": 0,
+      "tooltip": "What channel to segment on. 0=grayscale, 1=red, 2=green, 3=blue. See https://cellpose.readthedocs.io/en/v3.1.1.1/settings.html#channels for details."
     },
     {
-        "name": "Nucleus Channel",
-        "arg_name": "nucleus_channel",
-        "value": 0,
-        "tooltip": "What channel contains nucleus. 0=grayscale, 1=red, 2=green, 3=blue. Unused for 'nuclei' model, where nuclei are in the segment channel. See https://cellpose.readthedocs.io/en/v3.1.1.1/settings.html#channels for details."
+      "name": "Nucleus Channel",
+      "arg_name": "nucleus_channel",
+      "value": 0,
+      "tooltip": "What channel contains nucleus. 0=grayscale, 1=red, 2=green, 3=blue. Unused for 'nuclei' model, where nuclei are in the segment channel. See https://cellpose.readthedocs.io/en/v3.1.1.1/settings.html#channels for details."
     },
     {
-        "name": "3D Segmentation",
-        "arg_name": "do_3D",
-        "value": false,
-        "tooltip": "Whether to do 3D segmentation. If True, will try to segment in 3D (XY, XZ, YZ). If False, will segment in 2D and combine with stitch_threshold."
+      "name": "3D Segmentation",
+      "arg_name": "do_3D",
+      "value": false,
+      "tooltip": "Whether to do 3D segmentation. If True, will try to segment in 3D (XY, XZ, YZ). If False, will segment in 2D and combine with stitch_threshold."
     },
     {
-        "name": "Stitch Threshold",
-        "arg_name": "stitch_threshold",
-        "value": 0.0,
-        "tooltip": "Threshold for stitching 2D segmentations together. Value is the IoU that constitutes an overlap and thus merge. Only used if do_3D is False and >0."
+      "name": "Stitch Threshold",
+      "arg_name": "stitch_threshold",
+      "value": 0.0,
+      "tooltip": "Threshold for stitching 2D segmentations together. Value is the IoU that constitutes an overlap and thus merge. Only used if do_3D is False and >0."
     },
     {
-        "name": "Cellprob Threshold",
-        "arg_name": "cellprob_threshold",
-        "value": 0.0,
-        "tooltip": "Threshold for flows to determine ROIs. Decrease to find more & larger ROIs, increase if too many ROIs (esp. in dim regions). See https://cellpose.readthedocs.io/en/v3.1.1.1/settings.html#cellprob-threshold for details."
+      "name": "Cellprob Threshold",
+      "arg_name": "cellprob_threshold",
+      "value": 0.0,
+      "tooltip": "Threshold for flows to determine ROIs. Decrease to find more & larger ROIs, increase if too many ROIs (esp. in dim regions). See https://cellpose.readthedocs.io/en/v3.1.1.1/settings.html#cellprob-threshold for details."
     },
     {
-        "name": "Flow Threshold",
-        "arg_name": "flow_threshold",
-        "value": 0.4,
-        "tooltip": "Threshold for flows to determine ROIs. Not used for 3D. See https://cellpose.readthedocs.io/en/v3.1.1.1/settings.html#cellprob-threshold for details."
+      "name": "Flow Threshold",
+      "arg_name": "flow_threshold",
+      "value": 0.4,
+      "tooltip": "Threshold for flows to determine ROIs. Not used for 3D. See https://cellpose.readthedocs.io/en/v3.1.1.1/settings.html#cellprob-threshold for details."
     },
     {
-        "name": "Num Iterations",
-        "arg_name": "niter",
-        "value": 0,
-        "tooltip": "Number of iterations to simulate dynamics for. By default (0/None), proportional to ROI diameter. See https://cellpose.readthedocs.io/en/v3.1.1.1/settings.html#number-of-iterations-niter for details."
+      "name": "Num Iterations",
+      "arg_name": "niter",
+      "value": 0,
+      "tooltip": "Number of iterations to simulate dynamics for. By default (0/None), proportional to ROI diameter. See https://cellpose.readthedocs.io/en/v3.1.1.1/settings.html#number-of-iterations-niter for details."
     },
     {
-        "name": "Anisotropy",
-        "arg_name": "anisotropy",
-        "value": null,
-        "dtype": "float",
-        "tooltip": "Optional rescaling factor for Z (e.g. set to 2.0 if Z is sampled half as dense as X or Y). Only used if do_3D is True."
+      "name": "Anisotropy",
+      "arg_name": "anisotropy",
+      "value": null,
+      "dtype": "float",
+      "tooltip": "Optional rescaling factor for Z (e.g. set to 2.0 if Z is sampled half as dense as X or Y). Only used if do_3D is True."
     },
     {
-        "name": "Channel axis",
-        "arg_name": "channel_axis",
-        "value": null,
-        "dtype": "int",
-        "tooltip": "Set the axis where channels are stored. 'None' means it tries to figure it out - useful if no/poor metadata and not loading properly."
+      "name": "Channel axis",
+      "arg_name": "channel_axis",
+      "value": null,
+      "dtype": "int",
+      "tooltip": "Set the axis where channels are stored. 'None' means it tries to figure it out - useful if no/poor metadata and not loading properly."
     },
     {
-        "name": "Z axis",
-        "arg_name": "z_axis",
-        "value": null,
-        "dtype": "int",
-        "tooltip": "Set the axis where Z slices are stored. 'None' means it tries to figure it out - useful if no/poor metadata and not loading properly."
+      "name": "Z axis",
+      "arg_name": "z_axis",
+      "value": null,
+      "dtype": "int",
+      "tooltip": "Set the axis where Z slices are stored. 'None' means it tries to figure it out - useful if no/poor metadata and not loading properly."
     },
     {
-        "name": "Batch size",
-        "arg_name": "batch_size",
-        "value": 64,
-        "tooltip": "Number of 224x224 patches to run simultaneously on the GPU. Can make smaller or bigger depending on GPU memory usage."
+      "name": "Batch size",
+      "arg_name": "batch_size",
+      "value": 64,
+      "tooltip": "Number of 224x224 patches to run simultaneously on the GPU. Can make smaller or bigger depending on GPU memory usage."
     },
     {
-        "name": "Minimum size",
-        "arg_name": "min_size",
-        "value": 15,
-        "tooltip": "Size (in pixels) of ROIs/to remove if lower. 0 will not remove any masks."
+      "name": "Minimum size",
+      "arg_name": "min_size",
+      "value": 15,
+      "tooltip": "Size (in pixels) of ROIs/to remove if lower. 0 will not remove any masks."
     }
   ]
 }

--- a/aiod_registry/manifests/cellposesam.json
+++ b/aiod_registry/manifests/cellposesam.json
@@ -12,18 +12,18 @@
         "title": "Cellpose-SAM: superhuman generalization for cellular segmentation",
         "doi": "10.1101/2025.04.28.651001",
         "authors": [
-            {
-                "name": "Marius Pachitariu",
-                "affiliation": "HHMI Janelia Research Campus, Ashburn, VA, USA"
-            },
-            {
-                "name": "Michael Rariden",
-                "affiliation": "HHMI Janelia Research Campus, Ashburn, VA, USA"
-            },
-            {
-                "name": "Carsen Stringer",
-                "affiliation": "HHMI Janelia Research Campus, Ashburn, VA, USA"
-            }
+          {
+            "name": "Marius Pachitariu",
+            "affiliation": "HHMI Janelia Research Campus, Ashburn, VA, USA"
+          },
+          {
+            "name": "Michael Rariden",
+            "affiliation": "HHMI Janelia Research Campus, Ashburn, VA, USA"
+          },
+          {
+            "name": "Carsen Stringer",
+            "affiliation": "HHMI Janelia Research Campus, Ashburn, VA, USA"
+          }
         ]
       }
     ]
@@ -32,101 +32,109 @@
     "cpsam": {
       "tasks": {
         "cyto": {
-          "location":"https://huggingface.co/mouseland/cellpose-sam/resolve/main/cpsam"
+          "locations": [
+            {
+              "location": "https://huggingface.co/mouseland/cellpose-sam/resolve/main/cpsam"
+            }
+          ]
         },
         "nuclei": {
-          "location":"https://huggingface.co/mouseland/cellpose-sam/resolve/main/cpsam"
+          "locations": [
+            {
+              "location": "https://huggingface.co/mouseland/cellpose-sam/resolve/main/cpsam"
+            }
+          ]
         }
       }
     }
   },
   "params": [
     {
-        "name": "Segment Channel",
-        "arg_name": "segment_channel",
-        "value": 0,
-        "tooltip": "What channel to segment on. 0=grayscale, 1=red, 2=green, 3=blue. See https://cellpose.readthedocs.io/en/latest/settings.html#channels for details."
+      "name": "Segment Channel",
+      "arg_name": "segment_channel",
+      "value": 0,
+      "tooltip": "What channel to segment on. 0=grayscale, 1=red, 2=green, 3=blue. See https://cellpose.readthedocs.io/en/latest/settings.html#channels for details."
     },
     {
-        "name": "3D Segmentation",
-        "arg_name": "do_3D",
-        "value": false,
-        "tooltip": "Whether to do 3D segmentation. If True, will try to segment in 3D (XY, XZ, YZ). If False, will segment in 2D and combine with stitch_threshold."
+      "name": "3D Segmentation",
+      "arg_name": "do_3D",
+      "value": false,
+      "tooltip": "Whether to do 3D segmentation. If True, will try to segment in 3D (XY, XZ, YZ). If False, will segment in 2D and combine with stitch_threshold."
     },
     {
-        "name": "Resample",
-        "arg_name": "resample",
-        "value": true,
-        "tooltip": "Whether to run dynamics at original image size (rather than likely smaller resized image). Slower, but more accurate boundaries."
+      "name": "Resample",
+      "arg_name": "resample",
+      "value": true,
+      "tooltip": "Whether to run dynamics at original image size (rather than likely smaller resized image). Slower, but more accurate boundaries."
     },
     {
-        "name": "Stitch Threshold",
-        "arg_name": "stitch_threshold",
-        "value": 0.0,
-        "tooltip": "Threshold for stitching 2D segmentations together. Value is the IoU that constitutes an overlap and thus merge. Only used if do_3D is False and >0."
+      "name": "Stitch Threshold",
+      "arg_name": "stitch_threshold",
+      "value": 0.0,
+      "tooltip": "Threshold for stitching 2D segmentations together. Value is the IoU that constitutes an overlap and thus merge. Only used if do_3D is False and >0."
     },
     {
-        "name": "Cellprob Threshold",
-        "arg_name": "cellprob_threshold",
-        "value": 0.0,
-        "tooltip": "Threshold for flows to determine ROIs. Decrease to find more & larger ROIs, increase if too many ROIs (esp. in dim regions). See https://cellpose.readthedocs.io/en/latest/settings.html#cellprob-threshold for details."
+      "name": "Cellprob Threshold",
+      "arg_name": "cellprob_threshold",
+      "value": 0.0,
+      "tooltip": "Threshold for flows to determine ROIs. Decrease to find more & larger ROIs, increase if too many ROIs (esp. in dim regions). See https://cellpose.readthedocs.io/en/latest/settings.html#cellprob-threshold for details."
     },
     {
-        "name": "Flow Threshold",
-        "arg_name": "flow_threshold",
-        "value": 0.4,
-        "tooltip": "Threshold for flows to determine ROIs. Not used for 3D. See https://cellpose.readthedocs.io/en/latest/settings.html#cellprob-threshold for details."
+      "name": "Flow Threshold",
+      "arg_name": "flow_threshold",
+      "value": 0.4,
+      "tooltip": "Threshold for flows to determine ROIs. Not used for 3D. See https://cellpose.readthedocs.io/en/latest/settings.html#cellprob-threshold for details."
     },
     {
-        "name": "Num Iterations",
-        "arg_name": "niter",
-        "value": 0,
-        "tooltip": "Number of iterations to simulate dynamics for. By default (0/None), proportional to ROI diameter. See https://cellpose.readthedocs.io/en/latest/settings.html#number-of-iterations-niter for details."
+      "name": "Num Iterations",
+      "arg_name": "niter",
+      "value": 0,
+      "tooltip": "Number of iterations to simulate dynamics for. By default (0/None), proportional to ROI diameter. See https://cellpose.readthedocs.io/en/latest/settings.html#number-of-iterations-niter for details."
     },
     {
-        "name": "Anisotropy",
-        "arg_name": "anisotropy",
-        "value": null,
-        "dtype": "float",
-        "tooltip": "Optional rescaling factor for Z (e.g. set to 2.0 if Z is sampled half as dense as X or Y). Only used if do_3D is True."
+      "name": "Anisotropy",
+      "arg_name": "anisotropy",
+      "value": null,
+      "dtype": "float",
+      "tooltip": "Optional rescaling factor for Z (e.g. set to 2.0 if Z is sampled half as dense as X or Y). Only used if do_3D is True."
     },
     {
-        "name": "Channel axis",
-        "arg_name": "channel_axis",
-        "value": null,
-        "dtype": "int",
-        "tooltip": "Set the axis where channels are stored. 'None' means it tries to figure it out - useful if no/poor metadata and not loading properly."
+      "name": "Channel axis",
+      "arg_name": "channel_axis",
+      "value": null,
+      "dtype": "int",
+      "tooltip": "Set the axis where channels are stored. 'None' means it tries to figure it out - useful if no/poor metadata and not loading properly."
     },
     {
-        "name": "Z axis",
-        "arg_name": "z_axis",
-        "value": null,
-        "dtype": "int",
-        "tooltip": "Set the axis where Z slices are stored. 'None' means it tries to figure it out - useful if no/poor metadata and not loading properly."
+      "name": "Z axis",
+      "arg_name": "z_axis",
+      "value": null,
+      "dtype": "int",
+      "tooltip": "Set the axis where Z slices are stored. 'None' means it tries to figure it out - useful if no/poor metadata and not loading properly."
     },
     {
-        "name": "Batch size",
-        "arg_name": "batch_size",
-        "value": 64,
-        "tooltip": "Number of 224x224 patches to run simultaneously on the GPU. Can make smaller or bigger depending on GPU memory usage."
+      "name": "Batch size",
+      "arg_name": "batch_size",
+      "value": 64,
+      "tooltip": "Number of 224x224 patches to run simultaneously on the GPU. Can make smaller or bigger depending on GPU memory usage."
     },
     {
-        "name": "Minimum size",
-        "arg_name": "min_size",
-        "value": 15,
-        "tooltip": "Size (in pixels) of ROIs/to remove if lower. 0 will not remove any masks."
+      "name": "Minimum size",
+      "arg_name": "min_size",
+      "value": 15,
+      "tooltip": "Size (in pixels) of ROIs/to remove if lower. 0 will not remove any masks."
     },
     {
-        "name": "Max size fraction",
-        "arg_name": "max_size_fraction",
-        "value": 0.4,
-        "tooltip": "Maximum size of ROIs as fraction of image size. Masks larger than this are removed."
+      "name": "Max size fraction",
+      "arg_name": "max_size_fraction",
+      "value": 0.4,
+      "tooltip": "Maximum size of ROIs as fraction of image size. Masks larger than this are removed."
     },
     {
-        "name": "Tile Overlap",
-        "arg_name": "tile_overlap",
-        "value": 0.1,
-        "tooltip": "Fraction of overlap of tiles when computing flows."
+      "name": "Tile Overlap",
+      "arg_name": "tile_overlap",
+      "value": 0.1,
+      "tooltip": "Fraction of overlap of tiles when computing flows."
     }
   ]
 }

--- a/aiod_registry/manifests/empanada.json
+++ b/aiod_registry/manifests/empanada.json
@@ -1,140 +1,176 @@
 {
-    "name": "Empanada",
-    "metadata": {
-      "description": "Empanada contains segmentation models for mitochondria, nuclei, and lipid droplets in EM images.",
-      "authors": [
-        {
-          "name": "Ryan Conrad",
-          "affiliation": "Center for Molecular Microscopy, Center for Cancer Research, National Cancer Institute, National Institutes of Health, Bethesda, MD 20892, USA"
-        },
-        {
-          "name": "Kedar Narayan",
-          "affiliation": "Center for Molecular Microscopy, Center for Cancer Research, National Cancer Institute, National Institutes of Health, Bethesda, MD 20892, USA"
-        }
-      ],
-      "pubs": [
-        {
-          "title": "Instance segmentation of mitochondria in electron microscopy images with a generalist deep learning model trained on a diverse dataset",
-          "info": "Main paper that describes model & data",
-          "url": "https://doi.org/10.1016/j.cels.2022.12.006"
-        }
-      ]
-    },
-    "versions": {
-      "MitoNet v1": {
-        "tasks": {
-          "mito": {
-            "location": "https://zenodo.org/record/6861565/files/MitoNet_v1.pth?download=1"
-          }
-        }
+  "name": "Empanada",
+  "metadata": {
+    "description": "Empanada contains segmentation models for mitochondria, nuclei, and lipid droplets in EM images.",
+    "authors": [
+      {
+        "name": "Ryan Conrad",
+        "affiliation": "Center for Molecular Microscopy, Center for Cancer Research, National Cancer Institute, National Institutes of Health, Bethesda, MD 20892, USA"
       },
-      "MitoNet Mini v1": {
-        "tasks": {
-          "mito": {
-            "location": "https://zenodo.org/record/6861565/files/MitoNet_v1_mini.pth?download=1"
-          }
-        }
-      },
-      "NucleoNet v1": {
-        "tasks": {
-          "nuclei": {
-            "location": "https://zenodo.org/records/15298854/files/PanopticDeepLabPR_663ba73a-0908-4f7d-b59e-88a2d3ea2e39_panoptic_deeplab_pointrend.pth?download=1"
-          }
-        }
-      },
-      "DropNet v1": {
-        "tasks": {
-          "drop": {
-            "location": "https://zenodo.org/records/15298854/files/PanopticDeepLabPR_b0d99498-6c99-4b45-844e-2b4dca58f24a_panoptic_deeplab_pointrend.pth?download=1"
-          }
+      {
+        "name": "Kedar Narayan",
+        "affiliation": "Center for Molecular Microscopy, Center for Cancer Research, National Cancer Institute, National Institutes of Health, Bethesda, MD 20892, USA"
+      }
+    ],
+    "pubs": [
+      {
+        "title": "Instance segmentation of mitochondria in electron microscopy images with a generalist deep learning model trained on a diverse dataset",
+        "info": "Main paper that describes model & data",
+        "url": "https://doi.org/10.1016/j.cels.2022.12.006"
+      }
+    ]
+  },
+  "versions": {
+    "MitoNet v1": {
+      "tasks": {
+        "mito": {
+          "locations": [
+            {
+              "location": "https://zenodo.org/record/6861565/files/MitoNet_v1.pth?download=1"
+            }
+          ]
         }
       }
     },
-    "params": [
-    {
-        "name": "Plane",
-        "arg_name": "plane",
-        "value": ["XY", "XZ", "YZ", "All"],
-        "tooltip": "Whether to use all planes (XY, XZ, YZ) or a single plane"
+    "MitoNet Mini v1": {
+      "tasks": {
+        "mito": {
+          "locations": [
+            {
+              "location": "https://zenodo.org/record/6861565/files/MitoNet_v1_mini.pth?download=1"
+            }
+          ]
+        }
+      }
     },
-    {
-        "name": "Downsampling",
-        "arg_name": "downsampling",
-        "value": [1, 2, 4, 8, 16, 32, 64],
-        "tooltip": "Downsampling factor for the input image"
+    "NucleoNet v1": {
+      "tasks": {
+        "nuclei": {
+          "locations": [
+            {
+              "location": "https://zenodo.org/records/15298854/files/PanopticDeepLabPR_663ba73a-0908-4f7d-b59e-88a2d3ea2e39_panoptic_deeplab_pointrend.pth?download=1"
+            }
+          ]
+        }
+      }
     },
-    {
-        "name": "Segmentation threshold",
-        "arg_name": "conf_threshold",
-        "value": 0.5,
-        "tooltip": "Confidence threshold for the segmentation"
-    },
-    {
-        "name": "Center threshold",
-        "arg_name": "center_threshold",
-        "value": 0.1,
-        "tooltip": "Confidence threshold for the center"
-    },
-    {
-        "name": "Minimum distance",
-        "arg_name": "min_distance",
-        "value": 3,
-        "tooltip": "Minimum distance between object centers"
-    },
-    {
-        "name": "Maximum objects",
-        "arg_name": "max_objects",
-        "value": 10000,
-        "tooltip": "Maximum number of objects to segment per class"
-    },
-    {
-        "name": "Semantic only",
-        "arg_name": "semantic_only",
-        "value": false,
-        "tooltip": "Only run semantic segmentation for all classes"
-    },
-    {
-        "name": "Fine boundaries",
-        "arg_name": "fine_boundaries",
-        "value": false,
-        "tooltip": "Finer boundaries between objects"
-    },
-    {
-        "name": "Fill holes",
-        "arg_name": "fill_holes_in_segmentation",
-        "value": false,
-        "tooltip": "Whether to fill holes in the segmentation masks"
-    },
-    {
-        "name": "Median Filter Size",
-        "arg_name": "median_slices",
-        "value": [1, 3, 5, 7, 9, 11],
-        "default": 3,
-        "tooltip": "Number of image slices over which to apply a median filter to semantic segmentation probabilities. Only applies to 3D/'All'."
-    },
-    {
-        "name": "Erode labels (px; 3D)",
-        "arg_name": "label_erosion",
-        "value": 0,
-        "tooltip": "Will erode objects in the masks by specified number of pixels before final consensus. Only applies to 3D/'All'."
-    },
-    {
-        "name": "Dilate labels (px; 3D)",
-        "arg_name": "label_dilation",
-        "value": 0,
-        "tooltip": "Will dilate objects in the masks by specified number of pixels before final consensus. Only applies to 3D/'All'."
-    },
-    {
-        "name": "Voxel Vote",
-        "arg_name": "pixel_vote_thr",
-        "value": 2,
-        "tooltip": "Number of stacks from ortho-plane inference in which a voxel must be labelled in order to end up in the consensus segmentation. Only applies to 3D/'All'."
-    },
-    {
-        "name": "Allow single-plane objects",
-        "arg_name": "allow_one_view",
-        "value": false,
-        "tooltip": "Whether to allow objects that are only segmented in a single plane (XY, XZ, or YZ) to be included in the final consensus segmentation. Only applies to 3D/'All'."
+    "DropNet v1": {
+      "tasks": {
+        "drop": {
+          "locations": [
+            {
+              "location": "https://zenodo.org/records/15298854/files/PanopticDeepLabPR_b0d99498-6c99-4b45-844e-2b4dca58f24a_panoptic_deeplab_pointrend.pth?download=1"
+            }
+          ]
+        }
+      }
     }
-    ]
-  }
+  },
+  "params": [
+    {
+      "name": "Plane",
+      "arg_name": "plane",
+      "value": [
+        "XY",
+        "XZ",
+        "YZ",
+        "All"
+      ],
+      "tooltip": "Whether to use all planes (XY, XZ, YZ) or a single plane"
+    },
+    {
+      "name": "Downsampling",
+      "arg_name": "downsampling",
+      "value": [
+        1,
+        2,
+        4,
+        8,
+        16,
+        32,
+        64
+      ],
+      "tooltip": "Downsampling factor for the input image"
+    },
+    {
+      "name": "Segmentation threshold",
+      "arg_name": "conf_threshold",
+      "value": 0.5,
+      "tooltip": "Confidence threshold for the segmentation"
+    },
+    {
+      "name": "Center threshold",
+      "arg_name": "center_threshold",
+      "value": 0.1,
+      "tooltip": "Confidence threshold for the center"
+    },
+    {
+      "name": "Minimum distance",
+      "arg_name": "min_distance",
+      "value": 3,
+      "tooltip": "Minimum distance between object centers"
+    },
+    {
+      "name": "Maximum objects",
+      "arg_name": "max_objects",
+      "value": 10000,
+      "tooltip": "Maximum number of objects to segment per class"
+    },
+    {
+      "name": "Semantic only",
+      "arg_name": "semantic_only",
+      "value": false,
+      "tooltip": "Only run semantic segmentation for all classes"
+    },
+    {
+      "name": "Fine boundaries",
+      "arg_name": "fine_boundaries",
+      "value": false,
+      "tooltip": "Finer boundaries between objects"
+    },
+    {
+      "name": "Fill holes",
+      "arg_name": "fill_holes_in_segmentation",
+      "value": false,
+      "tooltip": "Whether to fill holes in the segmentation masks"
+    },
+    {
+      "name": "Median Filter Size",
+      "arg_name": "median_slices",
+      "value": [
+        1,
+        3,
+        5,
+        7,
+        9,
+        11
+      ],
+      "default": 3,
+      "tooltip": "Number of image slices over which to apply a median filter to semantic segmentation probabilities. Only applies to 3D/'All'."
+    },
+    {
+      "name": "Erode labels (px; 3D)",
+      "arg_name": "label_erosion",
+      "value": 0,
+      "tooltip": "Will erode objects in the masks by specified number of pixels before final consensus. Only applies to 3D/'All'."
+    },
+    {
+      "name": "Dilate labels (px; 3D)",
+      "arg_name": "label_dilation",
+      "value": 0,
+      "tooltip": "Will dilate objects in the masks by specified number of pixels before final consensus. Only applies to 3D/'All'."
+    },
+    {
+      "name": "Voxel Vote",
+      "arg_name": "pixel_vote_thr",
+      "value": 2,
+      "tooltip": "Number of stacks from ortho-plane inference in which a voxel must be labelled in order to end up in the consensus segmentation. Only applies to 3D/'All'."
+    },
+    {
+      "name": "Allow single-plane objects",
+      "arg_name": "allow_one_view",
+      "value": false,
+      "tooltip": "Whether to allow objects that are only segmented in a single plane (XY, XZ, or YZ) to be included in the final consensus segmentation. Only applies to 3D/'All'."
+    }
+  ]
+}

--- a/aiod_registry/manifests/plantseg2.json
+++ b/aiod_registry/manifests/plantseg2.json
@@ -65,18 +65,18 @@
           },
           {
             "name": "Marion Louveaux",
-            "affiliation": "Laboratoire Reproduction et Développement des Plantes, Université de Lyon, ENS de Lyon, CNRS, INRAE, Lyon, France"
+            "affiliation": "Laboratoire Reproduction et D\u00e9veloppement des Plantes, Universit\u00e9 de Lyon, ENS de Lyon, CNRS, INRAE, Lyon, France"
           },
           {
             "name": "Christian Wenzl",
             "affiliation": "Centre for Organismal Studies, Heidelberg University, Heidelberg, Germany"
           },
           {
-            "name": "Sören Strauss",
+            "name": "S\u00f6ren Strauss",
             "affiliation": "Centre for Organismal Studies, Heidelberg University, Heidelberg, Germany"
           },
           {
-            "name": "David Wilson-Sánchez",
+            "name": "David Wilson-S\u00e1nchez",
             "affiliation": "Centre for Organismal Studies, Heidelberg University, Heidelberg, Germany"
           },
           {
@@ -99,119 +99,187 @@
     "generic_confocal_3D_unet": {
       "tasks": {
         "boundaries": {
-          "location": "https://zenodo.org/record/7805434/files/unet3d-arabidopsis-ovules-confocal-ds2x.pytorch"
+          "locations": [
+            {
+              "location": "https://zenodo.org/record/7805434/files/unet3d-arabidopsis-ovules-confocal-ds2x.pytorch"
+            }
+          ]
         }
       }
     },
     "generic_light_sheet_3D_unet": {
       "tasks": {
         "boundaries": {
-          "location": "https://zenodo.org/record/7765026/files/unet3d-lateral-root-lightsheet-ds1x.pytorch"
+          "locations": [
+            {
+              "location": "https://zenodo.org/record/7765026/files/unet3d-lateral-root-lightsheet-ds1x.pytorch"
+            }
+          ]
         }
       }
     },
     "confocal_3D_unet_ovules_ds1x": {
       "tasks": {
         "boundaries": {
-          "location": "https://zenodo.org/record/7772553/files/unet3d-arabidopsis-ovules-confocal-ds1x.pytorch"
+          "locations": [
+            {
+              "location": "https://zenodo.org/record/7772553/files/unet3d-arabidopsis-ovules-confocal-ds1x.pytorch"
+            }
+          ]
         }
       }
     },
     "confocal_3D_unet_ovules_ds2x": {
       "tasks": {
         "boundaries": {
-          "location": "https://zenodo.org/record/7805434/files/unet3d-arabidopsis-ovules-confocal-ds2x.pytorch"
+          "locations": [
+            {
+              "location": "https://zenodo.org/record/7805434/files/unet3d-arabidopsis-ovules-confocal-ds2x.pytorch"
+            }
+          ]
         }
       }
     },
     "confocal_3D_unet_ovules_ds3x": {
       "tasks": {
         "boundaries": {
-          "location": "https://zenodo.org/record/7772532/files/unet3d-arabidopsis-ovules-confocal-ds3x.pytorch"
+          "locations": [
+            {
+              "location": "https://zenodo.org/record/7772532/files/unet3d-arabidopsis-ovules-confocal-ds3x.pytorch"
+            }
+          ]
         }
       }
     },
     "confocal_2D_unet_ovules_ds2x": {
       "tasks": {
         "boundaries": {
-          "location": "https://zenodo.org/record/7772709/files/confocal_2D_unet_ovules_ds2x.pytorch"
+          "locations": [
+            {
+              "location": "https://zenodo.org/record/7772709/files/confocal_2D_unet_ovules_ds2x.pytorch"
+            }
+          ]
         }
       }
     },
     "lightsheet_3D_unet_root_ds1x": {
       "tasks": {
         "boundaries": {
-          "location": "https://zenodo.org/record/7765026/files/unet3d-lateral-root-lightsheet-ds1x.pytorch"
+          "locations": [
+            {
+              "location": "https://zenodo.org/record/7765026/files/unet3d-lateral-root-lightsheet-ds1x.pytorch"
+            }
+          ]
         }
       }
     },
     "lightsheet_3D_unet_root_ds2x": {
       "tasks": {
         "boundaries": {
-          "location": "https://zenodo.org/record/7774122/files/unet3d-lateral-root-lightsheet-ds2x.pytorch"
+          "locations": [
+            {
+              "location": "https://zenodo.org/record/7774122/files/unet3d-lateral-root-lightsheet-ds2x.pytorch"
+            }
+          ]
         }
       }
     },
     "lightsheet_3D_unet_root_ds3x": {
       "tasks": {
         "boundaries": {
-          "location": "https://zenodo.org/record/7774145/files/unet3d-lateral-root-lightsheet-ds3x.pytorch"
+          "locations": [
+            {
+              "location": "https://zenodo.org/record/7774145/files/unet3d-lateral-root-lightsheet-ds3x.pytorch"
+            }
+          ]
         }
       }
     },
     "lightsheet_2D_unet_root_ds1x": {
       "tasks": {
         "boundaries": {
-          "location": "https://zenodo.org/record/7774537/files/unet2d-lateral-root-lightsheet.pytorch"
+          "locations": [
+            {
+              "location": "https://zenodo.org/record/7774537/files/unet2d-lateral-root-lightsheet.pytorch"
+            }
+          ]
         }
       }
     },
     "lightsheet_3D_unet_root_nuclei_ds1x": {
       "tasks": {
         "nuclei": {
-          "location": "https://zenodo.org/record/7774421/files/unet3d-lateral-root-nuclei-lightsheet.pytorch"
+          "locations": [
+            {
+              "location": "https://zenodo.org/record/7774421/files/unet3d-lateral-root-nuclei-lightsheet.pytorch"
+            }
+          ]
         }
       }
     },
     "lightsheet_2D_unet_root_nuclei_ds1x": {
       "tasks": {
         "nuclei": {
-          "location": "https://zenodo.org/record/7774563/files/unet2d-lateral-root-nuclei-lightsheet.pytorch"
+          "locations": [
+            {
+              "location": "https://zenodo.org/record/7774563/files/unet2d-lateral-root-nuclei-lightsheet.pytorch"
+            }
+          ]
         }
       }
     },
     "confocal_2D_unet_sa_meristem_cells": {
       "tasks": {
         "boundaries": {
-          "location": "https://zenodo.org/record/7781054/files/confocal_2d_unet_apical_stem.pytorch"
+          "locations": [
+            {
+              "location": "https://zenodo.org/record/7781054/files/confocal_2d_unet_apical_stem.pytorch"
+            }
+          ]
         }
       }
     },
     "confocal_3D_unet_sa_meristem_cells": {
       "tasks": {
         "boundaries": {
-          "location": "https://zenodo.org/record/7768142/files/confocal_pnas_3d.pytorch"
+          "locations": [
+            {
+              "location": "https://zenodo.org/record/7768142/files/confocal_pnas_3d.pytorch"
+            }
+          ]
         }
       }
     },
     "lightsheet_3D_unet_mouse_embryo_cells": {
       "tasks": {
         "boundaries": {
-          "location": "https://zenodo.org/record/7774490/files/unet-bce-dice-cell-boundary-311021.pytorch"
+          "locations": [
+            {
+              "location": "https://zenodo.org/record/7774490/files/unet-bce-dice-cell-boundary-311021.pytorch"
+            }
+          ]
         }
       }
     },
     "confocal_3D_unet_mouse_embryo_nuclei": {
       "tasks": {
         "nuclei": {
-          "location": "https://zenodo.org/record/7774505/files/unet-bce-dice-ab-nuclei-boundary-090121.pytorch"
+          "locations": [
+            {
+              "location": "https://zenodo.org/record/7774505/files/unet-bce-dice-ab-nuclei-boundary-090121.pytorch"
+            }
+          ]
         }
       }
     },
     "PlantSeg_3Dnuc_platinum": {
       "tasks": {
         "nuclei": {
-          "location": "https://zenodo.org/records/10070349/files/FOR2581_PlantSeg_Plant_Nuclei_3D.pytorch"
+          "locations": [
+            {
+              "location": "https://zenodo.org/records/10070349/files/FOR2581_PlantSeg_Plant_Nuclei_3D.pytorch"
+            }
+          ]
         }
       }
     }

--- a/aiod_registry/manifests/sam.json
+++ b/aiod_registry/manifests/sam.json
@@ -54,7 +54,7 @@
             "affiliation": "Meta AI Research, FAIR"
           },
           {
-            "name": "Piotr Dollár",
+            "name": "Piotr Doll\u00e1r",
             "affiliation": "Meta AI Research, FAIR"
           },
           {
@@ -69,35 +69,55 @@
     "default": {
       "tasks": {
         "everything": {
-          "location": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth"
+          "locations": [
+            {
+              "location": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth"
+            }
+          ]
         }
       }
     },
     "vit_h": {
       "tasks": {
         "everything": {
-          "location": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth"
+          "locations": [
+            {
+              "location": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth"
+            }
+          ]
         }
       }
     },
     "vit_l": {
       "tasks": {
         "everything": {
-          "location": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_l_0b3195.pth"
+          "locations": [
+            {
+              "location": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_l_0b3195.pth"
+            }
+          ]
         }
       }
     },
     "vit_b": {
       "tasks": {
         "everything": {
-          "location":"https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth"
+          "locations": [
+            {
+              "location": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth"
+            }
+          ]
         }
       }
     },
     "MedSAM": {
       "tasks": {
         "everything": {
-          "location": "https://syncandshare.desy.de/index.php/s/yLfdFbpfEGSHJWY/download/medsam_20230423_vit_b_0.0.1.pth"
+          "locations": [
+            {
+              "location": "https://syncandshare.desy.de/index.php/s/yLfdFbpfEGSHJWY/download/medsam_20230423_vit_b_0.0.1.pth"
+            }
+          ]
         }
       }
     },
@@ -116,7 +136,11 @@
       },
       "tasks": {
         "everything": {
-          "location": "https://zenodo.org/records/10524894/files/vit_b_em_boundaries.pth?download=1"
+          "locations": [
+            {
+              "location": "https://zenodo.org/records/10524894/files/vit_b_em_boundaries.pth?download=1"
+            }
+          ]
         }
       }
     },
@@ -135,83 +159,87 @@
       },
       "tasks": {
         "everything": {
-          "location": "https://zenodo.org/records/10524828/files/vit_b_em_organelles.pth?download=1"
+          "locations": [
+            {
+              "location": "https://zenodo.org/records/10524828/files/vit_b_em_organelles.pth?download=1"
+            }
+          ]
         }
       }
     }
   },
   "params": [
     {
-        "name": "Points per side",
-        "arg_name": "points_per_side",
-        "value": 32,
-        "tooltip": "Number of point prompts per side, controlling density of point grid. Higher values will capture more objects (rightly or wrongly), but take longer to run."
+      "name": "Points per side",
+      "arg_name": "points_per_side",
+      "value": 32,
+      "tooltip": "Number of point prompts per side, controlling density of point grid. Higher values will capture more objects (rightly or wrongly), but take longer to run."
     },
     {
-        "name": "Points per batch",
-        "arg_name": "points_per_batch",
-        "value": 64,
-        "tooltip": "Number of points to process per batch. Higher values will be faster but will require more (GPU) memory."
+      "name": "Points per batch",
+      "arg_name": "points_per_batch",
+      "value": 64,
+      "tooltip": "Number of points to process per batch. Higher values will be faster but will require more (GPU) memory."
     },
     {
-        "name": "Pred IoU threshold",
-        "arg_name": "pred_iou_thresh",
-        "value": 0.88,
-        "tooltip": "Threshold (range [0,1]) for model-predicted IoU, for filtering out low-confidence masks. Higher values will remove more masks."
+      "name": "Pred IoU threshold",
+      "arg_name": "pred_iou_thresh",
+      "value": 0.88,
+      "tooltip": "Threshold (range [0,1]) for model-predicted IoU, for filtering out low-confidence masks. Higher values will remove more masks."
     },
     {
-        "name": "Stability score threshold",
-        "arg_name": "stability_score_thresh",
-        "value": 0.95,
-        "tooltip": "Threshold (range [0,1]) for mask stability score. Higher values will remove more masks, in conjunction with stability score offset that controls level of stability measured."
+      "name": "Stability score threshold",
+      "arg_name": "stability_score_thresh",
+      "value": 0.95,
+      "tooltip": "Threshold (range [0,1]) for mask stability score. Higher values will remove more masks, in conjunction with stability score offset that controls level of stability measured."
     },
     {
-        "name": "Stability score offset",
-        "arg_name": "stability_score_offset",
-        "value": 1.0,
-        "tooltip": "Amount to shift the cutoff for stability score. Higher values will remove less stable masks."
+      "name": "Stability score offset",
+      "arg_name": "stability_score_offset",
+      "value": 1.0,
+      "tooltip": "Amount to shift the cutoff for stability score. Higher values will remove less stable masks."
     },
     {
-        "name": "Box NMS IoU threshold",
-        "arg_name": "box_nms_thresh",
-        "value": 0.7,
-        "tooltip": "The IoU threshold (range [0,1]) for non-maximum suppression of boxes. Lower values will merge more masks, useful to reduce mask 'halos' and speed-up postprocessing, but could lead to undersegmentation/agglomeration."
+      "name": "Box NMS IoU threshold",
+      "arg_name": "box_nms_thresh",
+      "value": 0.7,
+      "tooltip": "The IoU threshold (range [0,1]) for non-maximum suppression of boxes. Lower values will merge more masks, useful to reduce mask 'halos' and speed-up postprocessing, but could lead to undersegmentation/agglomeration."
     },
     {
-        "name": "Crop N layers",
-        "arg_name": "crop_n_layers",
-        "value": 0,
-        "tooltip": "Values >0 will crop the image into N layers, which will be processed separately, giving more detail but taking longer. Each deeper layer will have more crops (2^N). Balance number of point prompts with 'Crop N points downscale factor'."
+      "name": "Crop N layers",
+      "arg_name": "crop_n_layers",
+      "value": 0,
+      "tooltip": "Values >0 will crop the image into N layers, which will be processed separately, giving more detail but taking longer. Each deeper layer will have more crops (2^N). Balance number of point prompts with 'Crop N points downscale factor'."
     },
     {
-        "name": "Crop NMS IoU threshold",
-        "arg_name": "crop_nms_thresh",
-        "value": 0.7,
-        "tooltip": "Same as Box NMS IoU threshold, but for each crop."
+      "name": "Crop NMS IoU threshold",
+      "arg_name": "crop_nms_thresh",
+      "value": 0.7,
+      "tooltip": "Same as Box NMS IoU threshold, but for each crop."
     },
     {
-        "name": "Crop overlap ratio",
-        "arg_name": "crop_overlap_ratio",
-        "value": 0.34133,
-        "tooltip": "The amount which crops overlap. Higher values may help identify more objects, but duplicates computation."
+      "name": "Crop overlap ratio",
+      "arg_name": "crop_overlap_ratio",
+      "value": 0.34133,
+      "tooltip": "The amount which crops overlap. Higher values may help identify more objects, but duplicates computation."
     },
     {
-        "name": "Crop N points downscale factor",
-        "arg_name": "crop_n_points_downscale_factor",
-        "value": 1,
-        "tooltip": "Value to be raised to the power of the crop layer will be used to scale down number of points per side in each crop. Higher values will reduce point grid density in deeper layers."
+      "name": "Crop N points downscale factor",
+      "arg_name": "crop_n_points_downscale_factor",
+      "value": 1,
+      "tooltip": "Value to be raised to the power of the crop layer will be used to scale down number of points per side in each crop. Higher values will reduce point grid density in deeper layers."
     },
     {
-        "name": "Min mask region area",
-        "arg_name": "min_mask_region_area",
-        "value": 3,
-        "tooltip": "Size (in pixels) of masks to remove if identified as a disconnected region or hole. 0 will not remove any masks."
+      "name": "Min mask region area",
+      "arg_name": "min_mask_region_area",
+      "value": 3,
+      "tooltip": "Size (in pixels) of masks to remove if identified as a disconnected region or hole. 0 will not remove any masks."
     },
     {
-        "name": "Max mask region area",
-        "arg_name": "max_mask_region_area",
-        "value": 0,
-        "tooltip": "Size (in pixels) of masks to remove if at least this size. 0 will not remove any masks."
+      "name": "Max mask region area",
+      "arg_name": "max_mask_region_area",
+      "value": 0,
+      "tooltip": "Size (in pixels) of masks to remove if at least this size. 0 will not remove any masks."
     }
   ]
 }

--- a/aiod_registry/manifests/sam2.json
+++ b/aiod_registry/manifests/sam2.json
@@ -7,202 +7,222 @@
     "url": "https://ai.meta.com/sam2/",
     "repo": "https://github.com/facebookresearch/segment-anything-2",
     "pubs": [
-        {
-            "title": "SAM 2: Segment Anything in Images and Videos",
-            "info": "Main paper that describes model & data",
-            "url": "https://ai.meta.com/research/publications/sam-2-segment-anything-in-images-and-videos/",
-            "authors": [
-                {
-                    "name": "Nikhila Ravi",
-                    "affiliation": "Meta AI Rsearch, FAIR"
-                },
-                {
-                    "name": "Valentin Gabeur",
-                    "affiliation": "Meta AI Rsearch, FAIR"
-                },
-                {
-                    "name": "Yuan-Ting Hu",
-                    "affiliation": "Meta AI Rsearch, FAIR"
-                },
-                {
-                    "name": "Ronghang Hu",
-                    "affiliation": "Meta AI Rsearch, FAIR"
-                },
-                {
-                    "name": "Chay Ryali",
-                    "affiliation": "Meta AI Rsearch, FAIR"
-                },
-                {
-                    "name": "Tengyu Ma",
-                    "affiliation": "Meta AI Rsearch, FAIR"
-                },
-                {
-                    "name": "Haitham Khedr",
-                    "affiliation": "Meta AI Rsearch, FAIR"
-                },
-                {
-                    "name": "Roman Rädle",
-                    "affiliation": "Meta AI Rsearch, FAIR"
-                },
-                {
-                    "name": "Chloe Rolland",
-                    "affiliation": "Meta AI Rsearch, FAIR"
-                },
-                {
-                    "name": "Laura Gustafson",
-                    "affiliation": "Meta AI Rsearch, FAIR"
-                },
-                {
-                    "name": "Eric Mintun",
-                    "affiliation": "Meta AI Rsearch, FAIR"
-                },
-                {
-                    "name": "Junting Pan",
-                    "affiliation": "Meta AI Rsearch, FAIR"
-                },
-                {
-                    "name": "Kalyan Vasudev Alwala",
-                    "affiliation": "Meta AI Rsearch, FAIR"
-                },
-                {
-                    "name": "Nicolas Carion",
-                    "affiliation": "Meta AI Rsearch, FAIR"
-                },
-                {
-                    "name": "Chao-Yuan Wu",
-                    "affiliation": "Meta AI Rsearch, FAIR"
-                },
-                {
-                    "name": "Ross Girshick",
-                    "affiliation": "Meta AI Rsearch, FAIR"
-                },
-                {
-                    "name": "Piotr Dollar",
-                    "affiliation": "Meta AI Rsearch, FAIR"
-                },
-                {
-                    "name": "Christoph Feichtenhofer",
-                    "affiliation": "Meta AI Rsearch, FAIR"
-                }
-            ]
-        }
+      {
+        "title": "SAM 2: Segment Anything in Images and Videos",
+        "info": "Main paper that describes model & data",
+        "url": "https://ai.meta.com/research/publications/sam-2-segment-anything-in-images-and-videos/",
+        "authors": [
+          {
+            "name": "Nikhila Ravi",
+            "affiliation": "Meta AI Rsearch, FAIR"
+          },
+          {
+            "name": "Valentin Gabeur",
+            "affiliation": "Meta AI Rsearch, FAIR"
+          },
+          {
+            "name": "Yuan-Ting Hu",
+            "affiliation": "Meta AI Rsearch, FAIR"
+          },
+          {
+            "name": "Ronghang Hu",
+            "affiliation": "Meta AI Rsearch, FAIR"
+          },
+          {
+            "name": "Chay Ryali",
+            "affiliation": "Meta AI Rsearch, FAIR"
+          },
+          {
+            "name": "Tengyu Ma",
+            "affiliation": "Meta AI Rsearch, FAIR"
+          },
+          {
+            "name": "Haitham Khedr",
+            "affiliation": "Meta AI Rsearch, FAIR"
+          },
+          {
+            "name": "Roman R\u00e4dle",
+            "affiliation": "Meta AI Rsearch, FAIR"
+          },
+          {
+            "name": "Chloe Rolland",
+            "affiliation": "Meta AI Rsearch, FAIR"
+          },
+          {
+            "name": "Laura Gustafson",
+            "affiliation": "Meta AI Rsearch, FAIR"
+          },
+          {
+            "name": "Eric Mintun",
+            "affiliation": "Meta AI Rsearch, FAIR"
+          },
+          {
+            "name": "Junting Pan",
+            "affiliation": "Meta AI Rsearch, FAIR"
+          },
+          {
+            "name": "Kalyan Vasudev Alwala",
+            "affiliation": "Meta AI Rsearch, FAIR"
+          },
+          {
+            "name": "Nicolas Carion",
+            "affiliation": "Meta AI Rsearch, FAIR"
+          },
+          {
+            "name": "Chao-Yuan Wu",
+            "affiliation": "Meta AI Rsearch, FAIR"
+          },
+          {
+            "name": "Ross Girshick",
+            "affiliation": "Meta AI Rsearch, FAIR"
+          },
+          {
+            "name": "Piotr Dollar",
+            "affiliation": "Meta AI Rsearch, FAIR"
+          },
+          {
+            "name": "Christoph Feichtenhofer",
+            "affiliation": "Meta AI Rsearch, FAIR"
+          }
+        ]
+      }
     ]
   },
   "versions": {
     "default": {
       "tasks": {
         "everything": {
-          "location": "https://dl.fbaipublicfiles.com/segment_anything_2/072824/sam2_hiera_base_plus.pt"
+          "locations": [
+            {
+              "location": "https://dl.fbaipublicfiles.com/segment_anything_2/072824/sam2_hiera_base_plus.pt"
+            }
+          ]
         }
       }
     },
     "hiera_base": {
-        "tasks": {
-          "everything": {
-            "location": "https://dl.fbaipublicfiles.com/segment_anything_2/072824/sam2_hiera_base_plus.pt"
-          }
+      "tasks": {
+        "everything": {
+          "locations": [
+            {
+              "location": "https://dl.fbaipublicfiles.com/segment_anything_2/072824/sam2_hiera_base_plus.pt"
+            }
+          ]
         }
-      },
+      }
+    },
     "hiera_small": {
       "tasks": {
         "everything": {
-          "location": "https://dl.fbaipublicfiles.com/segment_anything_2/072824/sam2_hiera_small.pt"
+          "locations": [
+            {
+              "location": "https://dl.fbaipublicfiles.com/segment_anything_2/072824/sam2_hiera_small.pt"
+            }
+          ]
         }
       }
     },
     "hiera_large": {
       "tasks": {
         "everything": {
-          "location": "https://dl.fbaipublicfiles.com/segment_anything_2/072824/sam2_hiera_large.pt"
+          "locations": [
+            {
+              "location": "https://dl.fbaipublicfiles.com/segment_anything_2/072824/sam2_hiera_large.pt"
+            }
+          ]
         }
       }
     },
     "hiera_tiny": {
       "tasks": {
         "everything": {
-          "location": "https://dl.fbaipublicfiles.com/segment_anything_2/072824/sam2_hiera_tiny.pt"
+          "locations": [
+            {
+              "location": "https://dl.fbaipublicfiles.com/segment_anything_2/072824/sam2_hiera_tiny.pt"
+            }
+          ]
         }
       }
     }
   },
   "params": [
     {
-        "name": "Points per side",
-        "arg_name": "points_per_side",
-        "value": 32,
-        "tooltip": "Number of point prompts per side, controlling density of point grid. Higher values will capture more objects (rightly or wrongly), but take longer to run."
+      "name": "Points per side",
+      "arg_name": "points_per_side",
+      "value": 32,
+      "tooltip": "Number of point prompts per side, controlling density of point grid. Higher values will capture more objects (rightly or wrongly), but take longer to run."
     },
     {
-        "name": "Points per batch",
-        "arg_name": "points_per_batch",
-        "value": 64,
-        "tooltip": "Number of points to process per batch. Higher values will be faster but will require more (GPU) memory."
+      "name": "Points per batch",
+      "arg_name": "points_per_batch",
+      "value": 64,
+      "tooltip": "Number of points to process per batch. Higher values will be faster but will require more (GPU) memory."
     },
     {
-        "name": "Pred IoU threshold",
-        "arg_name": "pred_iou_thresh",
-        "value": 0.88,
-        "tooltip": "Threshold (range [0,1]) for model-predicted IoU, for filtering out low-confidence masks. Higher values will remove more masks."
+      "name": "Pred IoU threshold",
+      "arg_name": "pred_iou_thresh",
+      "value": 0.88,
+      "tooltip": "Threshold (range [0,1]) for model-predicted IoU, for filtering out low-confidence masks. Higher values will remove more masks."
     },
     {
-        "name": "Stability score threshold",
-        "arg_name": "stability_score_thresh",
-        "value": 0.95,
-        "tooltip": "Threshold (range [0,1]) for mask stability score. Higher values will remove more masks, in conjunction with stability score offset that controls level of stability measured."
+      "name": "Stability score threshold",
+      "arg_name": "stability_score_thresh",
+      "value": 0.95,
+      "tooltip": "Threshold (range [0,1]) for mask stability score. Higher values will remove more masks, in conjunction with stability score offset that controls level of stability measured."
     },
     {
-        "name": "Stability score offset",
-        "arg_name": "stability_score_offset",
-        "value": 1.0,
-        "tooltip": "Amount to shift the cutoff for stability score. Higher values will remove less stable masks."
+      "name": "Stability score offset",
+      "arg_name": "stability_score_offset",
+      "value": 1.0,
+      "tooltip": "Amount to shift the cutoff for stability score. Higher values will remove less stable masks."
     },
     {
-        "name": "Box NMS IoU threshold",
-        "arg_name": "box_nms_thresh",
-        "value": 0.7,
-        "tooltip": "The IoU threshold (range [0,1]) for non-maximum suppression of boxes. Lower values will merge more masks, useful to reduce mask 'halos' and speed-up postprocessing, but could lead to undersegmentation/agglomeration."
+      "name": "Box NMS IoU threshold",
+      "arg_name": "box_nms_thresh",
+      "value": 0.7,
+      "tooltip": "The IoU threshold (range [0,1]) for non-maximum suppression of boxes. Lower values will merge more masks, useful to reduce mask 'halos' and speed-up postprocessing, but could lead to undersegmentation/agglomeration."
     },
     {
-        "name": "Crop N layers",
-        "arg_name": "crop_n_layers",
-        "value": 0,
-        "tooltip": "Values >0 will crop the image into N layers, which will be processed separately, giving more detail but taking longer. Each deeper layer will have more crops (2^N). Balance number of point prompts with 'Crop N points downscale factor'."
+      "name": "Crop N layers",
+      "arg_name": "crop_n_layers",
+      "value": 0,
+      "tooltip": "Values >0 will crop the image into N layers, which will be processed separately, giving more detail but taking longer. Each deeper layer will have more crops (2^N). Balance number of point prompts with 'Crop N points downscale factor'."
     },
     {
-        "name": "Crop NMS IoU threshold",
-        "arg_name": "crop_nms_thresh",
-        "value": 0.7,
-        "tooltip": "Same as Box NMS IoU threshold, but for each crop."
+      "name": "Crop NMS IoU threshold",
+      "arg_name": "crop_nms_thresh",
+      "value": 0.7,
+      "tooltip": "Same as Box NMS IoU threshold, but for each crop."
     },
     {
-        "name": "Crop overlap ratio",
-        "arg_name": "crop_overlap_ratio",
-        "value": 0.34133,
-        "tooltip": "The amount which crops overlap. Higher values may help identify more objects, but duplicates computation."
+      "name": "Crop overlap ratio",
+      "arg_name": "crop_overlap_ratio",
+      "value": 0.34133,
+      "tooltip": "The amount which crops overlap. Higher values may help identify more objects, but duplicates computation."
     },
     {
-        "name": "Crop N points downscale factor",
-        "arg_name": "crop_n_points_downscale_factor",
-        "value": 1,
-        "tooltip": "Value to be raised to the power of the crop layer will be used to scale down number of points per side in each crop. Higher values will reduce point grid density in deeper layers."
+      "name": "Crop N points downscale factor",
+      "arg_name": "crop_n_points_downscale_factor",
+      "value": 1,
+      "tooltip": "Value to be raised to the power of the crop layer will be used to scale down number of points per side in each crop. Higher values will reduce point grid density in deeper layers."
     },
     {
-        "name": "Min mask region area",
-        "arg_name": "min_mask_region_area",
-        "value": 0,
-        "tooltip": "Size (in pixels) of masks to remove if identified as a disconnected region or hole. 0 will not remove any masks."
+      "name": "Min mask region area",
+      "arg_name": "min_mask_region_area",
+      "value": 0,
+      "tooltip": "Size (in pixels) of masks to remove if identified as a disconnected region or hole. 0 will not remove any masks."
     },
     {
-        "name": "Use previous mask refinement",
-        "arg_name": "use_m2m",
-        "value": false,
-        "tooltip": "Tick to use one-step refinement using previous mask predictions."
+      "name": "Use previous mask refinement",
+      "arg_name": "use_m2m",
+      "value": false,
+      "tooltip": "Tick to use one-step refinement using previous mask predictions."
     },
     {
-        "name": "Multimask output",
-        "arg_name": "multimask_output",
-        "value": false,
-        "tooltip": "Tick to output multiple masks at each grid point prompt."
+      "name": "Multimask output",
+      "arg_name": "multimask_output",
+      "value": false,
+      "tooltip": "Tick to output multiple masks at each grid point prompt."
     }
   ]
 }

--- a/aiod_registry/manifests/seai_unet.json
+++ b/aiod_registry/manifests/seai_unet.json
@@ -22,36 +22,72 @@
     "U-Net": {
       "tasks": {
         "mito": {
-          "location": ["/nemo/stp/ddt/outputs/aiod_models/mito_5nm_intensity_augs_warp.best.969.pt", "/media/DATA/aiod_models/mito_5nm_intensity_augs_warp.best.969.pt"],
-          "config_path": ["/nemo/stp/ddt/outputs/aiod_models/mito_5nm_intensity_augs_warp.yml", "/media/DATA/aiod_models/mito_5nm_intensity_augs_warp.yml"]
+          "locations": [
+            {
+              "location": "/nemo/stp/ddt/outputs/aiod_models/mito_5nm_intensity_augs_warp.best.969.pt",
+              "config_path": "/nemo/stp/ddt/outputs/aiod_models/mito_5nm_intensity_augs_warp.yml"
+            },
+            {
+              "location": "/media/DATA/aiod_models/mito_5nm_intensity_augs_warp.best.969.pt",
+              "config_path": "/media/DATA/aiod_models/mito_5nm_intensity_augs_warp.yml"
+            }
+          ]
         }
       }
     },
     "Finetuned HU-Net": {
       "tasks": {
         "er": {
-          "location": "/nemo/stp/ddt/outputs/carltonj/er_model/lr_0_00001.best.873.pt",
-          "config_path": "/nemo/stp/ddt/outputs/carltonj/er_model/er.yml"
+          "locations": [
+            {
+              "location": "/nemo/stp/ddt/outputs/carltonj/er_model/lr_0_00001.best.873.pt",
+              "config_path": "/nemo/stp/ddt/outputs/carltonj/er_model/er.yml"
+            }
+          ]
         }
       }
     },
     "Attention U-Net": {
       "tasks": {
         "mito": {
-          "location": ["/nemo/stp/ddt/outputs/aiod_models/Attention_HUNet_3e5_Adam_restart_12_16.best.1266.pt", "/media/DATA/aiod_models/Attention_HUNet_3e5_Adam_restart_12_16.best.1266.pt"],
-          "config_path": ["/nemo/stp/ddt/outputs/aiod_models/Attention_HUNet_3e5_Adam_restart_12_16.yml", "/media/DATA/aiod_models/Attention_HUNet_3e5_Adam_restart_12_16.yml"]
+          "locations": [
+            {
+              "location": "/nemo/stp/ddt/outputs/aiod_models/Attention_HUNet_3e5_Adam_restart_12_16.best.1266.pt",
+              "config_path": "/nemo/stp/ddt/outputs/aiod_models/Attention_HUNet_3e5_Adam_restart_12_16.yml"
+            },
+            {
+              "location": "/media/DATA/aiod_models/Attention_HUNet_3e5_Adam_restart_12_16.best.1266.pt",
+              "config_path": "/media/DATA/aiod_models/Attention_HUNet_3e5_Adam_restart_12_16.yml"
+            },
+            {
+              "location": "/Users/shandc/Documents/ai_ondemand/models/Attention_HUNet_3e5_Adam_restart_12_16.best.1266.pt",
+              "config_path": "/Users/shandc/Documents/ai_ondemand/models/Attention_HUNet_3e5_Adam_restart_12_16.yml"
+            }
+          ]
         },
         "ne": {
-          "location": ["/nemo/stp/ddt/outputs/aiod_models/Attention_HUNet_NE.best.368.pt", "/media/DATA/aiod_models/Attention_HUNet_NE.best.368.pt"],
-          "config_path": ["/nemo/stp/ddt/outputs/aiod_models/Attention_HUNet_NE.yml", "/media/DATA/aiod_models/Attention_HUNet_NE.yml"]
+          "locations": [
+            {
+              "location": "/nemo/stp/ddt/outputs/aiod_models/Attention_HUNet_NE.best.368.pt",
+              "config_path": "/nemo/stp/ddt/outputs/aiod_models/Attention_HUNet_NE.yml"
+            },
+            {
+              "location": "/media/DATA/aiod_models/Attention_HUNet_NE.best.368.pt",
+              "config_path": "/media/DATA/aiod_models/Attention_HUNet_NE.yml"
+            }
+          ]
         }
       }
     },
     "Finetuned Attention U-Net": {
       "tasks": {
         "ne": {
-          "location": "/nemo/stp/ddt/outputs/carltonj/ne_model/ne_epoch1500_lr0.00005.best.1827.pt",
-          "config_path": "/nemo/stp/ddt/outputs/carltonj/ne_model/ne_epoch1500_lr0.00005.yml"
+          "locations": [
+            {
+              "location": "/nemo/stp/ddt/outputs/carltonj/ne_model/ne_epoch1500_lr0.00005.best.1827.pt",
+              "config_path": "/nemo/stp/ddt/outputs/carltonj/ne_model/ne_epoch1500_lr0.00005.yml"
+            }
+          ]
         }
       }
     }

--- a/aiod_registry/schema.json
+++ b/aiod_registry/schema.json
@@ -307,6 +307,12 @@
             }
           ],
           "default": null
+        },
+        "slug": {
+          "default": "",
+          "description": "Filesystem-safe identifier derived from the version name (lowercase, spaces replaced with underscores). Auto-derived if not set.",
+          "title": "Slug",
+          "type": "string"
         }
       },
       "required": [

--- a/aiod_registry/schema.json
+++ b/aiod_registry/schema.json
@@ -69,6 +69,34 @@
       "title": "Author",
       "type": "object"
     },
+    "LocationEntry": {
+      "additionalProperties": false,
+      "properties": {
+        "location": {
+          "description": "A URL or file path to the model artifact.",
+          "title": "Location",
+          "type": "string"
+        },
+        "config_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional path or URL to the config file paired with this location.",
+          "title": "Config Path"
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "title": "LocationEntry",
+      "type": "object"
+    },
     "Metadata": {
       "additionalProperties": false,
       "properties": {
@@ -201,8 +229,29 @@
               "type": "null"
             }
           ],
-          "description": "Default parameter value. If a list, the parameters will be treated as dropdown choices, where the first is the default. The type of the first element will be used to determine the type of the parameter.",
+          "description": "Default parameter value. If a list, the parameters will be treated as dropdown choices. Use the `default` field on ModelParam to specify which item is selected by default (otherwise the first item is used). The type of the default (or first) element determines the parameter type.",
           "title": "Value"
+        },
+        "default": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Default"
         },
         "tooltip": {
           "anyOf": [
@@ -269,38 +318,14 @@
     "ModelVersionTask": {
       "additionalProperties": false,
       "properties": {
-        "location": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          ],
-          "description": "A url or a filepath, or list of alternative locations (skipped if location does not exist/cannot be read!)",
-          "title": "Location"
-        },
-        "config_path": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Config Path"
+        "locations": {
+          "description": "Ordered list of (location, config_path) pairs. The first accessible entry is used.",
+          "items": {
+            "$ref": "#/$defs/LocationEntry"
+          },
+          "minItems": 1,
+          "title": "Locations",
+          "type": "array"
         },
         "params": {
           "anyOf": [
@@ -330,7 +355,7 @@
         }
       },
       "required": [
-        "location"
+        "locations"
       ],
       "title": "ModelVersionTask",
       "type": "object"
@@ -411,16 +436,9 @@
       "type": "string"
     },
     "short_name": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "title": "Short Name"
+      "default": "",
+      "title": "Short Name",
+      "type": "string"
     },
     "versions": {
       "additionalProperties": {

--- a/aiod_registry/schema.py
+++ b/aiod_registry/schema.py
@@ -175,25 +175,23 @@ class Metadata(StrictModel):
         return f"Description: {self.description}\n{misc_info if len(misc_info) > 0 else ''}{all_pubs}"
 
 
-class ModelVersionTask(StrictModel):
-    location: Union[str, list[str]] = Field(
-        ...,
-        description="A url or a filepath, or list of alternative locations (skipped if location does not exist/cannot be read!)",
+class LocationEntry(StrictModel):
+    location: str = Field(..., description="A URL or file path to the model artifact.")
+    config_path: Optional[str] = Field(
+        None,
+        description="Optional path or URL to the config file paired with this location.",
     )
-    config_path: Optional[Union[str, list[str]]] = None
+
+
+class ModelVersionTask(StrictModel):
+    locations: list[LocationEntry] = Field(
+        ...,
+        description="Ordered list of (location, config_path) pairs. The first accessible entry is used.",
+        min_length=1,
+    )
     params: Optional[list[ModelParam]] = None
     metadata: Optional[Metadata] = None
     _params_inherited: bool = PrivateAttr(default=False)
-
-    @model_validator(mode="after")
-    def get_config_path(self):
-        if not isinstance(self.location, list):
-            self.location = [self.location]
-        if self.config_path is None:
-            self.config_path = [None] * len(self.location)
-        elif not isinstance(self.config_path, list):
-            self.config_path = [self.config_path]
-        return self
 
 
 class ModelVersion(StrictModel):

--- a/aiod_registry/schema.py
+++ b/aiod_registry/schema.py
@@ -197,6 +197,10 @@ class ModelVersionTask(StrictModel):
 class ModelVersion(StrictModel):
     tasks: dict[Task, ModelVersionTask]
     metadata: Optional[Metadata] = None
+    slug: str = Field(
+        default="",
+        description="Filesystem-safe identifier derived from the version name (lowercase, spaces replaced with underscores). Auto-derived if not set.",
+    )
 
 
 class ModelManifest(StrictModel):
@@ -222,6 +226,13 @@ class ModelManifest(StrictModel):
                 if task.params is None and self.params is not None:
                     task.params = self.params
                     task._params_inherited = True
+        return self
+
+    @model_validator(mode="after")
+    def fill_version_slugs(self):
+        for version_name, version in self.versions.items():
+            if not version.slug:
+                version.slug = shorten_name(version_name)
         return self
 
 

--- a/aiod_registry/utils.py
+++ b/aiod_registry/utils.py
@@ -28,26 +28,21 @@ def is_accessible(location: str | None) -> bool:
 
 def flatten_manifest(manifest: ModelManifest) -> ModelManifest:
     """
-    Flatten the manifest by just taking the first location and its type, same for config_path.
+    Flatten the manifest by keeping only the first location entry.
     """
     # Make a deep copy of the manifest
     new_manifest = manifest.model_copy(deep=True)
-    # Just take the first location and its type, same for config_path
+    # Keep only the first (location, config_path) pair for each task
     for v_name, version in manifest.versions.items():
         for task_name, task in version.tasks.items():
-            new_manifest.versions[v_name].tasks[task_name].location = task.location[0]
-            new_manifest.versions[v_name].tasks[task_name].config_path = (
-                task.config_path[0] if task.config_path else None
-            )
+            new_manifest.versions[v_name].tasks[task_name].locations = [task.locations[0]]
     return new_manifest
 
 
 def filter_location(manifest: ModelManifest) -> tuple[ModelManifest, bool, int]:
     """
-    Filter and flatten the location, and config_path fields in the manifest.
-    We take the first accessible location and its type.
-    Then take the first accessible config path.
-    If nothing is accessible, set the fields to None.
+    Filter the locations list to the first accessible (location, config_path) pair.
+    If no entry is accessible, remove the task entirely.
     """
     num = 0
     changed = False
@@ -56,20 +51,9 @@ def filter_location(manifest: ModelManifest) -> tuple[ModelManifest, bool, int]:
     # Loop through the versions and tasks and remove inaccessible ones
     for v_name, version in manifest.versions.items():
         for task_name, task in version.tasks.items():
-            # Check model config path and flatten
-            for fpath in task.config_path:  # type: ignore[union-attr]
-                if is_accessible(fpath):
-                    res = fpath
-                    break
-            else:
-                res = None
-            new_manifest.versions[v_name].tasks[task_name].config_path = res
-            # Check which location is accessible and flatten
-            for i, loc in enumerate(task.location):
-                if is_accessible(loc):
-                    # Store the first accessible location
-                    new_manifest.versions[v_name].tasks[task_name].location = loc
-                    # NOTE: Not including config path here in case not paired order
+            for entry in task.locations:
+                if is_accessible(entry.location):
+                    new_manifest.versions[v_name].tasks[task_name].locations = [entry]
                     break
             # If no location is accessible, remove the task completely
             else:
@@ -140,11 +124,9 @@ def load_manifests(
                 )
             return new_manifests
         else:
-            # NOTE: Locations etc. at least get flattened so we return the new manifests
             return new_manifests
     else:
-        # We still want to flatten the manifests for consistency
-        return {k: flatten_manifest(v) for k, v in manifests.items()}
+        return manifests
 
 
 def _params_to_yaml(params: list) -> str:

--- a/aiod_registry/utils.py
+++ b/aiod_registry/utils.py
@@ -26,6 +26,24 @@ def is_accessible(location: str | None) -> bool:
         return True
 
 
+def resolve_version(manifest: ModelManifest, version_input: str) -> str:
+    """Return the registry key for a version given its exact name or slug.
+
+    Tries an exact key match first, then falls back to slug matching.
+    Raises KeyError with a helpful message if neither matches.
+    """
+    if version_input in manifest.versions:
+        return version_input
+    for key, version in manifest.versions.items():
+        if version.slug == version_input:
+            return key
+    available = {k: v.slug for k, v in manifest.versions.items()}
+    raise KeyError(
+        f"Version '{version_input}' not found in manifest '{manifest.name}'. "
+        f"Available versions (name: slug): {available}"
+    )
+
+
 def flatten_manifest(manifest: ModelManifest) -> ModelManifest:
     """
     Flatten the manifest by keeping only the first location entry.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,14 +45,14 @@ EXAMPLE_MANIFEST = {
         "cyto3": {
             "tasks": {
                 "cyto": {
-                    "location": [
-                        "https://www.cellpose.org/models/cyto3",
-                        "file:///nonexistent/path",
+                    "locations": [
+                        {"location": "https://www.cellpose.org/models/cyto3"},
+                        {"location": "file:///nonexistent/path"},
                     ]
                 }
             }
         },
-        "cyto2": {"tasks": {"cyto": {"location": ["file:///nonexistent/path"]}}},
+        "cyto2": {"tasks": {"cyto": {"locations": [{"location": "file:///nonexistent/path"}]}}},
     },
     "params": [
         {
@@ -84,14 +84,14 @@ def test_load_manifests_basic(temp_manifest_file):
 
 
 def test_flatten_manifest(temp_manifest_file):
-    # Instantiate directly from raw JSON so location is still a list pre-flatten
     with open(temp_manifest_file) as f:
         raw_json = json.load(f)
     manifest = ModelManifest(**raw_json)
     flat = flatten_manifest(manifest)
-    # Should have string, not list, for location
-    loc = flat.versions["cyto3"].tasks["cyto"].location
-    assert isinstance(loc, str)
+    # Should have exactly one LocationEntry after flattening
+    locations = flat.versions["cyto3"].tasks["cyto"].locations
+    assert len(locations) == 1
+    assert isinstance(locations[0].location, str)
 
 
 def test_filter_location_and_empty_manifests(temp_manifest_file):
@@ -113,6 +113,48 @@ def test_filter_location_and_empty_manifests(temp_manifest_file):
     assert filtered.short_name in filtered_dict
 
 
+def test_filter_location_preserves_paired_config_path():
+    # The accessible entry's config_path must be retained alongside its location.
+    manifest_data = {
+        "name": "PairedConfig",
+        "short_name": "paired_config",
+        "metadata": {"description": "Test paired config_path"},
+        "versions": {
+            "v1": {
+                "tasks": {
+                    "mito": {
+                        "locations": [
+                            {"location": "file:///nonexistent/path", "config_path": "file:///nonexistent/cfg1.yml"},
+                            {"location": "https://example.com/model", "config_path": "/nonexistent/cfg2.yml"},
+                        ]
+                    }
+                }
+            }
+        },
+    }
+    manifest = ModelManifest(**manifest_data)
+    filtered, changed, num_removed = filter_location(manifest)
+    assert changed is False
+    task = filtered.versions["v1"].tasks["mito"]
+    assert len(task.locations) == 1
+    assert task.locations[0].location == "https://example.com/model"
+    assert task.locations[0].config_path == "/nonexistent/cfg2.yml"
+
+
+def test_empty_locations_raises():
+    from pydantic import ValidationError
+    manifest_data = {
+        "name": "Bad Model",
+        "short_name": "bad_model",
+        "metadata": {"description": "Test"},
+        "versions": {
+            "v1": {"tasks": {"cyto": {"locations": []}}}
+        },
+    }
+    with pytest.raises(ValidationError):
+        ModelManifest(**manifest_data)
+
+
 def test_filter_location_no_change(tmp_path):
     # Manifest with all accessible locations (URLs)
     manifest_data = {
@@ -125,9 +167,9 @@ def test_filter_location_no_change(tmp_path):
             "v1": {
                 "tasks": {
                     "cyto": {
-                        "location": [
-                            "https://example.com/model1",
-                            "https://example.com/model2",
+                        "locations": [
+                            {"location": "https://example.com/model1"},
+                            {"location": "https://example.com/model2"},
                         ],
                     }
                 }
@@ -237,7 +279,7 @@ MANIFEST_WITH_LIST_PARAMS = {
     "versions": {
         "v1": {
             "tasks": {
-                "cyto": {"location": "https://example.com/model"}
+                "cyto": {"locations": [{"location": "https://example.com/model"}]}
             }
         }
     },
@@ -263,7 +305,7 @@ MANIFEST_NO_PARAMS = {
     "versions": {
         "v1": {
             "tasks": {
-                "mito": {"location": "https://example.com/model"}
+                "mito": {"locations": [{"location": "https://example.com/model"}]}
             }
         }
     },
@@ -376,7 +418,7 @@ def test_short_name_auto_derived_from_name():
         "name": "My Cool Model",
         "metadata": {"description": "Test"},
         "versions": {
-            "v1": {"tasks": {"cyto": {"location": "https://example.com/model"}}}
+            "v1": {"tasks": {"cyto": {"locations": [{"location": "https://example.com/model"}]}}}
         },
     }
     manifest = ModelManifest(**manifest_data)
@@ -393,7 +435,7 @@ def test_params_inherited_flag_task_level():
             "v1": {
                 "tasks": {
                     "cyto": {
-                        "location": "https://example.com/model",
+                        "locations": [{"location": "https://example.com/model"}],
                         "params": [{"name": "Threshold", "arg_name": "threshold", "value": 0.5}],
                     }
                 }
@@ -416,7 +458,7 @@ def test_save_all_default_configs_task_specific_file(tmp_path):
             "v1": {
                 "tasks": {
                     "cyto": {
-                        "location": "https://example.com/model",
+                        "locations": [{"location": "https://example.com/model"}],
                         "params": [{"name": "Threshold", "arg_name": "threshold", "value": 0.5}],
                     }
                 }


### PR DESCRIPTION
Previously there was an implication that model locations and their corresponding configs were paired, but this was not enforced. Similarly, `location` did not make it clear that multiple locations could be specified.

This also led to some odd choices around flattening, which acted as a filter in itself (filtering for the 0th item rather than accessibility).

During the fix for this, it also became clear that model versions with spaces in the name were inconsistently handled, so that's been bundled in across all AIOD-302 PRs.

I've updated the schema, old manifests, and tests accordingly!